### PR TITLE
修复当路径中含有空格的时候shell执行失败的问题

### DIFF
--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -32,7 +32,17 @@ Starter.prototype.prepare = function(main,message,clients){
 	var count = parseInt(message.agent,10) || 1;
     for(var ipindex in clients) {
         for (var i = 0;i<count;i++) {
-        var cmd = 'cd ' + process.cwd() + ' && ' + process.execPath + ' ' + main + ' client > log/.log';
+            // 修复当路径中含有空格的时候shell执行失败的问题
+            var fixPath = function (path) {
+                if (path && path.indexOf(' ') >= 0) {
+                    path = '"' + path + '"';
+                }
+                return path;
+            }
+            var cwd = fixPath(process.cwd());
+            var execPath = fixPath(process.execPath);
+            var fixMain = fixPath(main);
+            var cmd = 'cd ' + cwd + ' && ' + execPath + ' ' + fixMain + ' client > log/.log';
             var ip = clients[ipindex];
             if (ip==='127.0.0.1') {
                 self.localrun(cmd);

--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -42,7 +42,7 @@ Starter.prototype.prepare = function(main,message,clients){
             var cwd = fixPath(process.cwd());
             var execPath = fixPath(process.execPath);
             var fixMain = fixPath(main);
-            var cmd = 'cd ' + cwd + ' && ' + execPath + ' ' + fixMain + ' client > log/.log';
+            var cmd = 'cd ' + cwd + ' && ' + execPath + ' ' + fixMain + ' client > log/' + i + '.log';
             var ip = clients[ipindex];
             if (ip==='127.0.0.1') {
                 self.localrun(cmd);


### PR DESCRIPTION
1.当路径存在空格时,shell会执行失败,比如在windows下node为默认安装时,路径在Program Files下时启动client会失败,解决方案是在判断路径存在空格时,在前后增加""
2.windows下多个agent同时写入同一个log会报文件占用冲突,因此修改为每个agent写一个log文件
